### PR TITLE
remove async when not necessary

### DIFF
--- a/lessons/231/python-app/main.py
+++ b/lessons/231/python-app/main.py
@@ -39,12 +39,12 @@ uvicorn_logger.addFilter(LogFilter())
 
 
 @app.get("/healthz", response_class=PlainTextResponse)
-async def health():
+def health():
     return "OK"
 
 
 @app.get("/api/devices", response_class=ORJSONResponse)
-async def get_devices():
+def get_devices():
     devices = [
         {
             "id": 1,


### PR DESCRIPTION
Removing async as prevents each worker from processing multiple requests at once